### PR TITLE
fixing id Generation

### DIFF
--- a/common/src/main/java/org/powertac/common/IdGenerator.java
+++ b/common/src/main/java/org/powertac/common/IdGenerator.java
@@ -35,8 +35,8 @@ public class IdGenerator
    */
   public static long createId() 
   {
-    return multiplier * prefix + counter++;
-    //return (long)multiplier * (long)prefix + (long)counter++;
+    //return multiplier * prefix + counter++;
+    return (long)multiplier * (long)prefix + (long)counter++;
   }
 
   /**

--- a/common/src/main/java/org/powertac/common/IdGenerator.java
+++ b/common/src/main/java/org/powertac/common/IdGenerator.java
@@ -36,6 +36,7 @@ public class IdGenerator
   public static long createId() 
   {
     return multiplier * prefix + counter++;
+    //return (long)multiplier * (long)prefix + (long)counter++;
   }
 
   /**

--- a/common/src/test/java/org/powertac/common/IdGeneratorTest.java
+++ b/common/src/test/java/org/powertac/common/IdGeneratorTest.java
@@ -1,0 +1,14 @@
+package org.powertac.common;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class IdGeneratorTest {
+
+	@Test
+	public void createId() {
+		IdGenerator.setPrefix(42);
+		assertTrue(IdGenerator.createId()>0);
+	}
+}


### PR DESCRIPTION
The calculation is based on ints right now which causes a wrap around at ~ 21 Billion (i.e. 22+ brokers)