### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+os:
+  - linux
+language: java
+jdk:
+  - oraclejdk8
+cache:
+  directories:
+    - $HOME/.m2


### PR DESCRIPTION
@jecollins This is a minimal Travis/Linux setup that just runs `mvn test` on new commits. We'll see a yellow circle while the CI is buliding, and subsequently a green V or a red X depending on the outcome.

Not sure what your intentions are with javadoc... On powertac-core, these are built with the `site` goal, not for every `mvn install`. But on powertac-server they are included with regular `install`s? This makes the regular build (and CI) even slower, I think I would prefer the separate goal for generating docs.

There are more advanced configurations possible, including auto-deploying certain builds to sonatype I think. But no time to dive into it further at the moment...