### PR TITLE
Javadox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ jdk:
 cache:
   directories:
     - $HOME/.m2
+script:
+  - mvn -nsu -B -Dmaven.javadoc.skip=true clean install

--- a/pom.xml
+++ b/pom.xml
@@ -660,6 +660,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
+
     </plugins>
 
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -578,31 +578,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <version>${maven-site.version}</version>
-          <configuration>
-            <reportPlugins>
-              <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven-javadoc.version}</version>
-                <reportSets>
-                  <reportSet>
-                    <reports>
-                      <report>aggregate</report>
-                    </reports>
-                  </reportSet>
-                </reportSets>
-                <configuration>
-                  <failOnError>false</failOnError>
-                  <additionalparam>-Xdoclint:none</additionalparam>
-                  <includeDependencySources>true</includeDependencySources>
-                  <dependencySourceIncludes>
-                    <dependencySourceInclude>org.powertac:*</dependencySourceInclude>
-                  </dependencySourceIncludes>
-                </configuration>
-              </plugin>
-            </reportPlugins>
-          </configuration>
-
         </plugin>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -664,7 +664,6 @@
 
   </build>
 
-
   <!-- Release profile -->
 
   <profiles>
@@ -672,14 +671,6 @@
       <id>sonatype-release</id>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-source-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -655,6 +655,11 @@
         <artifactId>maven-source-plugin</artifactId>
       </plugin>
 
+      <!-- Make sure to always attach javadoc jars -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+      </plugin>
     </plugins>
 
   </build>


### PR DESCRIPTION
@jecollins This makes sure that the per-module install attaches a javadoc into local `~/.m2/` for the benefit of our IDEs, and it strips the aggregate configuration out (will add it to powertac-server, as you seem to prefer an all-in-one doc jar).